### PR TITLE
Startupopts

### DIFF
--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -78,3 +78,18 @@ jobs:
           grep "deploying" buildlog.txt
           grep "checking" buildlog.txt
           rm buildlog.txt
+
+      - name: Run build with startup options
+        uses: ./
+        with:
+          startup-options: -logfile buildlog2.txt
+
+      - name: Verify tasks appear in buildlog2.txt
+        run: |
+          set -e
+          grep "build" buildlog2.txt
+          grep "test" buildlog2.txt
+          ! grep "deploy" buildlog2.txt
+          ! grep "check" buildlog2.txt
+          rm buildlog.txt
+          rm buildlog2.txt

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,11 @@ inputs:
       Space-separated list of tasks to run
     required: false
     default: ""
+  statup-options:
+    description: >-
+      Startup options for MATLAB
+    required: false
+    default: ""
 runs:
   using: node16
   main: dist/index.js

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
       Space-separated list of tasks to run
     required: false
     default: ""
-  statup-options:
+  startup-options:
     description: >-
       Startup options for MATLAB
     required: false

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-# Copyright 2022 The MathWorks, Inc.
+# Copyright 2022-2023 The MathWorks, Inc.
 
 name: Run MATLAB Build
 description: >-

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "dependencies": {
                 "@actions/core": "^1.4.0",
                 "@actions/exec": "^1.1.0",
-                "run-matlab-command-action": "github:matlab-actions/run-command#v1.1.0"
+                "run-matlab-command-action": "github:matlab-actions/run-command#v1.2.0"
             },
             "devDependencies": {
                 "@types/jest": "^27.0.3",
@@ -6962,7 +6962,7 @@
         },
         "run-matlab-command-action": {
             "version": "git+ssh://git@github.com/matlab-actions/run-command.git#d00fcac6684c63b0ab07e04a438c18151032326e",
-            "from": "run-matlab-command-action@github:matlab-actions/run-command#v1.1.0",
+            "from": "run-matlab-command-action@github:matlab-actions/run-command#v1.2.0",
             "requires": {
                 "@actions/core": "^1.4.0",
                 "@actions/exec": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,9 +25,9 @@
             }
         },
         "node_modules/@actions/core": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.9.1.tgz",
-            "integrity": "sha512-5ad+U2YGrmmiw6du20AQW5XuWo7UKN2052FjSV7MX+Wfjf8sCqcsZe62NfgHys4QI4/Y+vQvLKYL8jWtA1ZBTA==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+            "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
             "dependencies": {
                 "@actions/http-client": "^2.0.1",
                 "uuid": "^8.3.2"
@@ -3529,10 +3529,10 @@
             }
         },
         "node_modules/run-matlab-command-action": {
-            "version": "1.1.0",
-            "resolved": "git+ssh://git@github.com/matlab-actions/run-command.git#d00fcac6684c63b0ab07e04a438c18151032326e",
+            "version": "1.2.0",
+            "resolved": "git+ssh://git@github.com/matlab-actions/run-command.git#0d8ebe96d99116ea06f2be9781282e441d83ba40",
             "dependencies": {
-                "@actions/core": "^1.4.0",
+                "@actions/core": "^1.10.0",
                 "@actions/exec": "^1.1.0",
                 "uuid": "^8.3.2"
             }
@@ -4253,9 +4253,9 @@
     },
     "dependencies": {
         "@actions/core": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.9.1.tgz",
-            "integrity": "sha512-5ad+U2YGrmmiw6du20AQW5XuWo7UKN2052FjSV7MX+Wfjf8sCqcsZe62NfgHys4QI4/Y+vQvLKYL8jWtA1ZBTA==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+            "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
             "requires": {
                 "@actions/http-client": "^2.0.1",
                 "uuid": "^8.3.2"
@@ -6961,10 +6961,10 @@
             }
         },
         "run-matlab-command-action": {
-            "version": "git+ssh://git@github.com/matlab-actions/run-command.git#d00fcac6684c63b0ab07e04a438c18151032326e",
+            "version": "git+ssh://git@github.com/matlab-actions/run-command.git#0d8ebe96d99116ea06f2be9781282e441d83ba40",
             "from": "run-matlab-command-action@github:matlab-actions/run-command#v1.2.0",
             "requires": {
-                "@actions/core": "^1.4.0",
+                "@actions/core": "^1.10.0",
                 "@actions/exec": "^1.1.0",
                 "uuid": "^8.3.2"
             }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "dependencies": {
         "@actions/core": "^1.4.0",
         "@actions/exec": "^1.1.0",
-        "run-matlab-command-action": "github:matlab-actions/run-command#v1.1.0"
+        "run-matlab-command-action": "github:matlab-actions/run-command#v1.2.0"
     },
     "devDependencies": {
         "@types/jest": "^27.0.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ async function run() {
     };
 
     const command = buildtool.generateCommand(options);
+    const startupOptions = core.getInput("startup-options").split(" ");
 
     const helperScript = await core.group("Generate script", async () => {
         const helperScript = await matlab.generateScript(workspaceDir, command);
@@ -26,7 +27,7 @@ async function run() {
     });
 
     await core.group("Run command", async () => {
-        await matlab.runCommand(helperScript, platform, architecture, exec.exec);
+        await matlab.runCommand(helperScript, platform, architecture, exec.exec, startupOptions);
     });
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2022 The MathWorks, Inc.
+// Copyright 2022-2023 The MathWorks, Inc.
 
 import * as core from "@actions/core";
 import * as exec from "@actions/exec";


### PR DESCRIPTION
Adding support for passing startup-options through. Strangely, updating the package.json for run-matlab-command-action didn't work (it missed a section of the package-lock.json) so I had to do it manually.