### PR TITLE
Added grouping workflow to the build logs of GitHub action 

### DIFF
--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -15,7 +15,8 @@ jobs:
 
       - name: Perform 'setup-matlab'
         uses: matlab-actions/setup-matlab@v2
-        release: latest
+        with:
+          release: latest
 
       - name: Create buildfile.m in project root for tests
         run: |

--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -170,3 +170,15 @@ jobs:
           grep "deploying" buildlog.txt
           ! grep "checking" buildlog.txt
           rm buildlog.txt
+
+      - name: Run build with multiple specified tasks
+        uses: ./
+        with:
+          tasks: deploy check
+
+      - name: Verify grouping workflow is added tasks appear in buildlog.txt
+        run: |
+          set -e
+          grep "::group::deploy" buildlog.txt
+          grep "::group::check" buildlog.txt
+          rm buildlog.txt

--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -15,6 +15,7 @@ jobs:
 
       - name: Perform 'setup-matlab'
         uses: matlab-actions/setup-matlab@v2
+        release: latest
 
       - name: Create buildfile.m in project root for tests
         run: |

--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -179,6 +179,6 @@ jobs:
       - name: Verify grouping workflow is added tasks appear in buildlog.txt
         run: |
           set -e
-          grep "::group::deploy" buildlog.txt
-          grep "::group::check" buildlog.txt
+          grep "group" buildlog.txt
+          grep "endgroup" buildlog.txt
           rm buildlog.txt

--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -177,7 +177,7 @@ jobs:
           tasks: deploy check
           startup-options: -logfile console.log
 
-      - name: Verify grouping workflow is added tasks appear in console.log
+      - name: Verify grouping workflow is added for tasks appear in console.log
         run: |
           set -e
           grep "::group::deploy" console.log

--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -15,8 +15,6 @@ jobs:
 
       - name: Perform 'setup-matlab'
         uses: matlab-actions/setup-matlab@v2
-        with:
-          release: latest
 
       - name: Create buildfile.m in project root for tests
         run: |

--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -175,10 +175,11 @@ jobs:
         uses: ./
         with:
           tasks: deploy check
+          startup-options: -logfile console.log
 
-      - name: Verify grouping workflow is added tasks appear in buildlog.txt
+      - name: Verify grouping workflow is added tasks appear in console.log
         run: |
           set -e
-          grep "group" buildlog.txt
-          grep "endgroup" buildlog.txt
-          rm buildlog.txt
+          grep "group" console.log
+          grep "endgroup" console.log
+          rm console.log

--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -180,6 +180,6 @@ jobs:
       - name: Verify grouping workflow is added tasks appear in console.log
         run: |
           set -e
-          grep "group" console.log
-          grep "endgroup" console.log
+          grep "::group::deploy" console.log
+          grep "::group::check" console.log
           rm console.log

--- a/package.json
+++ b/package.json
@@ -10,8 +10,6 @@
         "format-check": "prettier --check .",
         "build": "tsc",
         "deps": "bash ./scripts/setupdeps.sh",
-        "make-dir": "mkdir -p $(pwd)/dist/plugins" ,
-        "copy": "cp -R ./plugins $(pwd)/dist/plugins",
         "package": "ncc build --minify",
         "test": "jest",
         "all": "npm test && npm run build && npm run package",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
         "format-check": "prettier --check .",
         "build": "tsc",
         "deps": "bash ./scripts/setupdeps.sh",
+        "make-dir": "mkdir -p $(pwd)/dist/plugins" ,
+        "copy": "cp -R plugins $(pwd)/dist/plugins",
         "package": "ncc build --minify",
         "test": "jest",
         "all": "npm test && npm run build && npm run package",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "build": "tsc",
         "deps": "bash ./scripts/setupdeps.sh",
         "make-dir": "mkdir -p $(pwd)/dist/plugins" ,
-        "copy": "cp -R plugins $(pwd)/dist/plugins",
+        "copy": "cp -R ./plugins $(pwd)/dist/plugins",
         "package": "ncc build --minify",
         "test": "jest",
         "all": "npm test && npm run build && npm run package",

--- a/plugins/+matlab/+ciplugins/+github/BuildTaskGroupPlugin.m
+++ b/plugins/+matlab/+ciplugins/+github/BuildTaskGroupPlugin.m
@@ -1,0 +1,14 @@
+classdef BuildTaskGroupPlugin < matlab.buildtool.plugins.BuildRunnerPlugin
+%
+
+%   Copyright 2024 The MathWorks, Inc.
+
+    methods (Access=protected)
+
+        function runTask(plugin, pluginData)
+            disp("::group::" + pluginData.TaskResults.Name );
+            runTask@matlab.buildtool.plugins.BuildRunnerPlugin(plugin, pluginData);
+            disp("::endgroup::");
+        end
+    end
+ end

--- a/plugins/+matlab/+ciplugins/+github/getDefaultPlugins.m
+++ b/plugins/+matlab/+ciplugins/+github/getDefaultPlugins.m
@@ -1,0 +1,13 @@
+function plugins = getDefaultPlugins(pluginProviderData)
+%
+
+%   Copyright 2024 The MathWorks, Inc.
+arguments
+    pluginProviderData (1,1) struct = struct();
+end
+
+plugins = [ ...
+    matlab.buildtool.internal.getFactoryDefaultPlugins(pluginProviderData) ...
+    matlab.ciplugins.github.BuildTaskGroupPlugin() ...
+];
+end

--- a/scripts/setupdeps.sh
+++ b/scripts/setupdeps.sh
@@ -9,7 +9,7 @@ mkdir -p $DISTDIR
 
 PLUGINDIR="$(pwd)/.matlab/plugins"
 mkdir -p $PLUGINDIR
-cp -R ./plugins $$PLUGINDIR
+cp -R plugins $$PLUGINDIR
 echo "$(pwd)"
 cd $PLUGINDIR/plugins/+matlab/+ciplugins/+github
 ls -ltra

--- a/scripts/setupdeps.sh
+++ b/scripts/setupdeps.sh
@@ -7,6 +7,10 @@ SUPPORTED_OS=('win64' 'maci64' 'maca64' 'glnxa64')
 DISTDIR="$(pwd)/dist/bin"
 mkdir -p $DISTDIR
 
+PLUGINDIR="$(GITHUB_WORKSPACE)/.matlab/plugins"
+mkdir -p $PLUGINDIR
+cp -R ./plugins $$PLUGINDIR
+
 # Download and extract in a temporary directory
 WORKINGDIR=$(mktemp -d -t rmc_build.XXXXXX)
 cd $WORKINGDIR

--- a/scripts/setupdeps.sh
+++ b/scripts/setupdeps.sh
@@ -10,6 +10,7 @@ mkdir -p $DISTDIR
 PLUGINDIR="$(pwd)/.matlab/plugins"
 mkdir -p $PLUGINDIR
 cp -R ./plugins $$PLUGINDIR
+echo "$(pwd)"
 
 # Download and extract in a temporary directory
 WORKINGDIR=$(mktemp -d -t rmc_build.XXXXXX)

--- a/scripts/setupdeps.sh
+++ b/scripts/setupdeps.sh
@@ -11,6 +11,8 @@ PLUGINDIR="$(pwd)/.matlab/plugins"
 mkdir -p $PLUGINDIR
 cp -R ./plugins $$PLUGINDIR
 echo "$(pwd)"
+cd $PLUGINDIR/plugins/+matlab/+ciplugins/+github
+ls -ltra
 
 # Download and extract in a temporary directory
 WORKINGDIR=$(mktemp -d -t rmc_build.XXXXXX)

--- a/scripts/setupdeps.sh
+++ b/scripts/setupdeps.sh
@@ -7,11 +7,11 @@ SUPPORTED_OS=('win64' 'maci64' 'maca64' 'glnxa64')
 DISTDIR="$(pwd)/dist/bin"
 mkdir -p $DISTDIR
 
-PLUGINDIR="$(pwd)/.matlab/plugins"
+PLUGINDIR="$(pwd)/.matlab/plugins/+matlab/+ciplugins/+github"
 mkdir -p $PLUGINDIR
-cp -R plugins $$PLUGINDIR
+cp -R plugins/+matlab/+ciplugins/+github/*.m $PLUGINDIR/
 echo "$(pwd)"
-cd $PLUGINDIR/plugins/+matlab/+ciplugins/+github
+cd $PLUGINDIR
 ls -ltra
 
 # Download and extract in a temporary directory

--- a/scripts/setupdeps.sh
+++ b/scripts/setupdeps.sh
@@ -7,10 +7,10 @@ SUPPORTED_OS=('win64' 'maci64' 'maca64' 'glnxa64')
 DISTDIR="$(pwd)/dist/bin"
 mkdir -p $DISTDIR
 
-# Create plugins directory for copying buildtool plugins
-# PLUGINDIR="$(pwd)/.matlab/plugins/+matlab/+ciplugins/+github"
-# mkdir -p $PLUGINDIR
-# cp -R plugins/+matlab/+ciplugins/+github/*.m $PLUGINDIR/
+# Create plugins directory and copy buildtool plugins
+PLUGINDIR="$(pwd)/.matlab/plugins/+matlab/+ciplugins/+github"
+mkdir -p $PLUGINDIR
+cp -R plugins/+matlab/+ciplugins/+github/*.m $PLUGINDIR/
 
 # Download and extract in a temporary directory
 WORKINGDIR=$(mktemp -d -t rmc_build.XXXXXX)

--- a/scripts/setupdeps.sh
+++ b/scripts/setupdeps.sh
@@ -8,9 +8,9 @@ DISTDIR="$(pwd)/dist/bin"
 mkdir -p $DISTDIR
 
 # Create plugins directory for copying buildtool plugins
-PLUGINDIR="$(pwd)/.matlab/plugins/+matlab/+ciplugins/+github"
-mkdir -p $PLUGINDIR
-cp -R plugins/+matlab/+ciplugins/+github/*.m $PLUGINDIR/
+# PLUGINDIR="$(pwd)/.matlab/plugins/+matlab/+ciplugins/+github"
+# mkdir -p $PLUGINDIR
+# cp -R plugins/+matlab/+ciplugins/+github/*.m $PLUGINDIR/
 
 # Download and extract in a temporary directory
 WORKINGDIR=$(mktemp -d -t rmc_build.XXXXXX)

--- a/scripts/setupdeps.sh
+++ b/scripts/setupdeps.sh
@@ -7,12 +7,10 @@ SUPPORTED_OS=('win64' 'maci64' 'maca64' 'glnxa64')
 DISTDIR="$(pwd)/dist/bin"
 mkdir -p $DISTDIR
 
+# Create plugins directory for copying buildtool plugins
 PLUGINDIR="$(pwd)/.matlab/plugins/+matlab/+ciplugins/+github"
 mkdir -p $PLUGINDIR
 cp -R plugins/+matlab/+ciplugins/+github/*.m $PLUGINDIR/
-echo "$(pwd)"
-cd $PLUGINDIR
-ls -ltra
 
 # Download and extract in a temporary directory
 WORKINGDIR=$(mktemp -d -t rmc_build.XXXXXX)

--- a/scripts/setupdeps.sh
+++ b/scripts/setupdeps.sh
@@ -7,7 +7,7 @@ SUPPORTED_OS=('win64' 'maci64' 'maca64' 'glnxa64')
 DISTDIR="$(pwd)/dist/bin"
 mkdir -p $DISTDIR
 
-PLUGINDIR="$(GITHUB_WORKSPACE)/.matlab/plugins"
+PLUGINDIR="$(pwd)/.matlab/plugins"
 mkdir -p $PLUGINDIR
 cp -R ./plugins $$PLUGINDIR
 

--- a/src/buildtool.ts
+++ b/src/buildtool.ts
@@ -6,7 +6,7 @@ export interface RunBuildOptions {
 }
 
 export function generateCommand(options: RunBuildOptions): string {
-    let command: string = "addpath(genpath('../plugins'));buildtool";
+    let command: string = "addpath(genpath('./dist/plugins'));buildtool";
     if (options.Tasks) {
         command = command + " " + options.Tasks;
     }

--- a/src/buildtool.ts
+++ b/src/buildtool.ts
@@ -6,7 +6,7 @@ export interface RunBuildOptions {
 }
 
 export function generateCommand(options: RunBuildOptions): string {
-    let command: string = "addpath(genpath('"+ process.cwd() +"/.matlab/plugins'));buildtool";
+    let command: string = "addpath(genpath('"+ process.cwd() +"/.matlab/plugins'));\n buildtool";
     if (options.Tasks) {
         command = command + " " + options.Tasks;
     }

--- a/src/buildtool.ts
+++ b/src/buildtool.ts
@@ -6,7 +6,7 @@ export interface RunBuildOptions {
 }
 
 export function generateCommand(options: RunBuildOptions): string {
-    let command: string = "buildtool";
+    let command: string = "addpath(genpath('../plugins'));buildtool";
     if (options.Tasks) {
         command = command + " " + options.Tasks;
     }

--- a/src/buildtool.ts
+++ b/src/buildtool.ts
@@ -6,7 +6,7 @@ export interface RunBuildOptions {
 }
 
 export function generateCommand(options: RunBuildOptions): string {
-    let command: string = "addpath(genpath('./dist/plugins'));buildtool";
+    let command: string = "addpath(genpath('"+ process.env.GITHUB_WORKSPACE +"/.matlab/plugins'));buildtool";
     if (options.Tasks) {
         command = command + " " + options.Tasks;
     }

--- a/src/buildtool.ts
+++ b/src/buildtool.ts
@@ -6,7 +6,7 @@ export interface RunBuildOptions {
 }
 
 export function generateCommand(options: RunBuildOptions): string {
-    let command: string = "addpath(genpath('"+ process.env.GITHUB_WORKSPACE +"/.matlab/plugins'));buildtool";
+    let command: string = "addpath(genpath('"+ process.cwd() +"/.matlab/plugins'));buildtool";
     if (options.Tasks) {
         command = command + " " + options.Tasks;
     }

--- a/src/buildtool.ts
+++ b/src/buildtool.ts
@@ -6,7 +6,7 @@ export interface RunBuildOptions {
 }
 
 export function generateCommand(options: RunBuildOptions): string {
-    let command: string = "addpath(genpath('"+ process.cwd() +"/.matlab/plugins'));\n buildtool";
+    let command: string = 'addpath(genpath('${process.cwd()}/.matlab/plugins'));\n buildtool';
     if (options.Tasks) {
         command = command + " " + options.Tasks;
     }

--- a/src/buildtool.ts
+++ b/src/buildtool.ts
@@ -6,7 +6,7 @@ export interface RunBuildOptions {
 }
 
 export function generateCommand(options: RunBuildOptions): string {
-    let command: string = 'addpath(genpath('${process.cwd()}/.matlab/plugins'));\n buildtool';
+    let command: string = "addpath(genpath('"+ process.cwd() +"/.matlab/plugins'));\n buildtool";
     if (options.Tasks) {
         command = command + " " + options.Tasks;
     }

--- a/src/buildtool.unit.test.ts
+++ b/src/buildtool.unit.test.ts
@@ -10,7 +10,7 @@ describe("command generation", () => {
         };
 
         const actual = buildtool.generateCommand(options);
-        expect(actual).toBe("addpath(genpath('./dist/plugins'));buildtool")
+        expect(actual).toBe("addpath(genpath('"+ process.env.GITHUB_WORKSPACE +"/.matlab/plugins'));buildtool")
     });
 
     it("buildtool invocation with tasks specified", () => {
@@ -19,7 +19,7 @@ describe("command generation", () => {
         };
 
         const actual = buildtool.generateCommand(options);
-        expect(actual).toBe("addpath(genpath('./dist/plugins'));buildtool compile test")
+        expect(actual).toBe("addpath(genpath('"+ process.env.GITHUB_WORKSPACE +"/.matlab/plugins'));buildtool compile test")
     });
 
     it("buildtool invocation with only build options", () => {
@@ -29,7 +29,7 @@ describe("command generation", () => {
         };
 
         const actual = buildtool.generateCommand(options);
-        expect(actual).toBe("addpath(genpath('./dist/plugins'));buildtool -continueOnFailure -skip check")
+        expect(actual).toBe("addpath(genpath('"+ process.env.GITHUB_WORKSPACE +"/.matlab/plugins'));buildtool -continueOnFailure -skip check")
     });
 
     it("buildtool invocation with specified tasks and build options", () => {
@@ -39,6 +39,6 @@ describe("command generation", () => {
         };
 
         const actual = buildtool.generateCommand(options);
-        expect(actual).toBe("addpath(genpath('./dist/plugins'));buildtool compile test -continueOnFailure -skip check")
+        expect(actual).toBe("addpath(genpath('"+ process.env.GITHUB_WORKSPACE +"/.matlab/plugins'));buildtool compile test -continueOnFailure -skip check")
     });
 });

--- a/src/buildtool.unit.test.ts
+++ b/src/buildtool.unit.test.ts
@@ -10,7 +10,7 @@ describe("command generation", () => {
         };
 
         const actual = buildtool.generateCommand(options);
-        expect(actual).toBe("addpath(genpath('../plugins'));buildtool")
+        expect(actual).toBe("addpath(genpath('./dist/plugins'));buildtool")
     });
 
     it("buildtool invocation with tasks specified", () => {
@@ -19,7 +19,7 @@ describe("command generation", () => {
         };
 
         const actual = buildtool.generateCommand(options);
-        expect(actual).toBe("addpath(genpath('../plugins'));buildtool compile test")
+        expect(actual).toBe("addpath(genpath('./dist/plugins'));buildtool")
     });
 
     it("buildtool invocation with only build options", () => {
@@ -29,7 +29,7 @@ describe("command generation", () => {
         };
 
         const actual = buildtool.generateCommand(options);
-        expect(actual).toBe("addpath(genpath('../plugins'));buildtool -continueOnFailure -skip check")
+        expect(actual).toBe("addpath(genpath('./dist/plugins'));buildtool -continueOnFailure -skip check")
     });
 
     it("buildtool invocation with specified tasks and build options", () => {
@@ -39,6 +39,6 @@ describe("command generation", () => {
         };
 
         const actual = buildtool.generateCommand(options);
-        expect(actual).toBe("addpath(genpath('../plugins'));buildtool compile test -continueOnFailure -skip check")
+        expect(actual).toBe("addpath(genpath('./dist/plugins'));buildtool compile test -continueOnFailure -skip check")
     });
 });

--- a/src/buildtool.unit.test.ts
+++ b/src/buildtool.unit.test.ts
@@ -10,7 +10,7 @@ describe("command generation", () => {
         };
 
         const actual = buildtool.generateCommand(options);
-        expect(actual).toBe("buildtool")
+        expect(actual).toBe("addpath(genpath('../plugins'));buildtool")
     });
 
     it("buildtool invocation with tasks specified", () => {
@@ -19,7 +19,7 @@ describe("command generation", () => {
         };
 
         const actual = buildtool.generateCommand(options);
-        expect(actual).toBe("buildtool compile test")
+        expect(actual).toBe("addpath(genpath('../plugins'));buildtool compile test")
     });
 
     it("buildtool invocation with only build options", () => {
@@ -29,7 +29,7 @@ describe("command generation", () => {
         };
 
         const actual = buildtool.generateCommand(options);
-        expect(actual).toBe("buildtool -continueOnFailure -skip check")
+        expect(actual).toBe("addpath(genpath('../plugins'));buildtool -continueOnFailure -skip check")
     });
 
     it("buildtool invocation with specified tasks and build options", () => {
@@ -39,6 +39,6 @@ describe("command generation", () => {
         };
 
         const actual = buildtool.generateCommand(options);
-        expect(actual).toBe("buildtool compile test -continueOnFailure -skip check")
+        expect(actual).toBe("addpath(genpath('../plugins'));buildtool compile test -continueOnFailure -skip check")
     });
 });

--- a/src/buildtool.unit.test.ts
+++ b/src/buildtool.unit.test.ts
@@ -10,7 +10,7 @@ describe("command generation", () => {
         };
 
         const actual = buildtool.generateCommand(options);
-        expect(actual).toBe("addpath(genpath('"+ process.cwd() +"/.matlab/plugins'));buildtool")
+        expect(actual).toBe("addpath(genpath('"+ process.cwd() +"/.matlab/plugins'));\n buildtool")
     });
 
     it("buildtool invocation with tasks specified", () => {
@@ -19,7 +19,7 @@ describe("command generation", () => {
         };
 
         const actual = buildtool.generateCommand(options);
-        expect(actual).toBe("addpath(genpath('"+ process.cwd() +"/.matlab/plugins'));buildtool compile test")
+        expect(actual).toBe("addpath(genpath('"+ process.cwd() +"/.matlab/plugins'));\n buildtool compile test")
     });
 
     it("buildtool invocation with only build options", () => {
@@ -29,7 +29,7 @@ describe("command generation", () => {
         };
 
         const actual = buildtool.generateCommand(options);
-        expect(actual).toBe("addpath(genpath('"+ process.cwd() +"/.matlab/plugins'));buildtool -continueOnFailure -skip check")
+        expect(actual).toBe("addpath(genpath('"+ process.cwd() +"/.matlab/plugins'));\n buildtool -continueOnFailure -skip check")
     });
 
     it("buildtool invocation with specified tasks and build options", () => {
@@ -39,6 +39,6 @@ describe("command generation", () => {
         };
 
         const actual = buildtool.generateCommand(options);
-        expect(actual).toBe("addpath(genpath('"+ process.cwd() +"/.matlab/plugins'));buildtool compile test -continueOnFailure -skip check")
+        expect(actual).toBe("addpath(genpath('"+ process.cwd() +"/.matlab/plugins'));\n buildtool compile test -continueOnFailure -skip check")
     });
 });

--- a/src/buildtool.unit.test.ts
+++ b/src/buildtool.unit.test.ts
@@ -19,7 +19,7 @@ describe("command generation", () => {
         };
 
         const actual = buildtool.generateCommand(options);
-        expect(actual).toBe("addpath(genpath('./dist/plugins'));buildtool")
+        expect(actual).toBe("addpath(genpath('./dist/plugins'));buildtool compile test")
     });
 
     it("buildtool invocation with only build options", () => {

--- a/src/buildtool.unit.test.ts
+++ b/src/buildtool.unit.test.ts
@@ -10,7 +10,7 @@ describe("command generation", () => {
         };
 
         const actual = buildtool.generateCommand(options);
-        expect(actual).toBe("addpath(genpath('"+ process.env.GITHUB_WORKSPACE +"/.matlab/plugins'));buildtool")
+        expect(actual).toBe("addpath(genpath('"+ process.cwd() +"/.matlab/plugins'));buildtool")
     });
 
     it("buildtool invocation with tasks specified", () => {
@@ -19,7 +19,7 @@ describe("command generation", () => {
         };
 
         const actual = buildtool.generateCommand(options);
-        expect(actual).toBe("addpath(genpath('"+ process.env.GITHUB_WORKSPACE +"/.matlab/plugins'));buildtool compile test")
+        expect(actual).toBe("addpath(genpath('"+ process.cwd() +"/.matlab/plugins'));buildtool compile test")
     });
 
     it("buildtool invocation with only build options", () => {
@@ -29,7 +29,7 @@ describe("command generation", () => {
         };
 
         const actual = buildtool.generateCommand(options);
-        expect(actual).toBe("addpath(genpath('"+ process.env.GITHUB_WORKSPACE +"/.matlab/plugins'));buildtool -continueOnFailure -skip check")
+        expect(actual).toBe("addpath(genpath('"+ process.cwd() +"/.matlab/plugins'));buildtool -continueOnFailure -skip check")
     });
 
     it("buildtool invocation with specified tasks and build options", () => {
@@ -39,6 +39,6 @@ describe("command generation", () => {
         };
 
         const actual = buildtool.generateCommand(options);
-        expect(actual).toBe("addpath(genpath('"+ process.env.GITHUB_WORKSPACE +"/.matlab/plugins'));buildtool compile test -continueOnFailure -skip check")
+        expect(actual).toBe("addpath(genpath('"+ process.cwd() +"/.matlab/plugins'));buildtool compile test -continueOnFailure -skip check")
     });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ async function run() {
     const platform = process.platform;
     const architecture = process.arch;
     const workspaceDir = process.cwd();
-    const pluginResources = "./plugins/+matlab/+ciplugins/+github"
+    const pluginResources = "./plugins/+matlab/+ciplugins/+github";
     core.exportVariable('MW_MATLAB_BUILDTOOL_DEFAULT_PLUGINS_FCN_OVERRIDE', 'matlab.ciplugins.github.getDefaultPlugins');
     const pluginDir = await io.mkdirP(workspaceDir + '/.matlab/plugins/+matlab/+ciplugins/+github');
     const opt = { recursive: true, force: false }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,9 +13,12 @@ async function run() {
     const platform = process.platform;
     const architecture = process.arch;
     const workspaceDir = process.cwd();
-    const pluginResources = "./plugins/+matlab/+ciplugins/+github";
+    const pluginResources = './plugins/+matlab/+ciplugins/+github';
+    const pluginDir = workspaceDir + '/.matlab/plugins/+matlab/+ciplugins/+github';
+
     core.exportVariable('MW_MATLAB_BUILDTOOL_DEFAULT_PLUGINS_FCN_OVERRIDE', 'matlab.ciplugins.github.getDefaultPlugins');
-    const pluginDir = await io.mkdirP(workspaceDir + '/.matlab/plugins/+matlab/+ciplugins/+github');
+    await io.mkdirP(pluginDir);
+
     const opt = { recursive: true, force: false }
     await io.cp(pluginResources, pluginDir, opt);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ async function run() {
     const architecture = process.arch;
     const workspaceDir = process.cwd();
 
-    // Export env varible to inject the buildtool plugin
+    // Export env variable to inject the buildtool plugin
     core.exportVariable('MW_MATLAB_BUILDTOOL_DEFAULT_PLUGINS_FCN_OVERRIDE', 'matlab.ciplugins.github.getDefaultPlugins');
 
     const options: buildtool.RunBuildOptions = {
@@ -35,7 +35,7 @@ async function run() {
         await matlab.runCommand(helperScript, platform, architecture, exec.exec, startupOptions);
     });
 
-    // Cleanup post run
+    // Cleanup post run for self hosted runners
     await io.rmRF(workspaceDir + '/.matlab');
 
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ async function run() {
     const platform = process.platform;
     const architecture = process.arch;
     const workspaceDir = process.cwd();
+    core.exportVariable('MW_MATLAB_BUILDTOOL_DEFAULT_PLUGINS_FCN_OVERRIDE', 'matlab.ciplugins.github.getDefaultPlugins');
 
     const options: buildtool.RunBuildOptions = {
         Tasks: core.getInput("tasks"),

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ async function run() {
     const platform = process.platform;
     const architecture = process.arch;
     const workspaceDir = process.cwd();
-    const pluginResources = './plugins/+matlab/+ciplugins/+github';
+    const pluginResources = '../plugins/+matlab/+ciplugins/+github';
     const pluginDir = workspaceDir + '/.matlab/plugins/+matlab/+ciplugins/+github';
 
     core.exportVariable('MW_MATLAB_BUILDTOOL_DEFAULT_PLUGINS_FCN_OVERRIDE', 'matlab.ciplugins.github.getDefaultPlugins');

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,11 @@ async function run() {
     const platform = process.platform;
     const architecture = process.arch;
     const workspaceDir = process.cwd();
+    const pluginResources = "./plugins/+matlab/+ciplugins/+github"
     core.exportVariable('MW_MATLAB_BUILDTOOL_DEFAULT_PLUGINS_FCN_OVERRIDE', 'matlab.ciplugins.github.getDefaultPlugins');
+    const pluginDir = await io.mkdirP(workspceDir + '/.matlab/plugins/+matlab/+ciplugins/+github');
+    const options = { recursive: true, force: false }
+    await io.cp(pluginResources, pluginDir, options);
 
     const options: buildtool.RunBuildOptions = {
         Tasks: core.getInput("tasks"),
@@ -33,7 +37,7 @@ async function run() {
         await matlab.runCommand(helperScript, platform, architecture, exec.exec, startupOptions);
     });
 
-    await io.rmRF(workspaceDir'/.matlab');
+    await io.rmRF(workspaceDir + '/.matlab');
 }
 
 run().catch((e) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,14 +13,9 @@ async function run() {
     const platform = process.platform;
     const architecture = process.arch;
     const workspaceDir = process.cwd();
-    const pluginResources = '../plugins/+matlab/+ciplugins/+github';
-    const pluginDir = workspaceDir + '/.matlab/plugins/+matlab/+ciplugins/+github';
 
+    // Export env varible to inject the buildtool plugin
     core.exportVariable('MW_MATLAB_BUILDTOOL_DEFAULT_PLUGINS_FCN_OVERRIDE', 'matlab.ciplugins.github.getDefaultPlugins');
-    await io.mkdirP(pluginDir);
-
-    const opt = { recursive: true, force: false }
-    await io.cp(pluginResources, pluginDir, opt);
 
     const options: buildtool.RunBuildOptions = {
         Tasks: core.getInput("tasks"),
@@ -40,7 +35,9 @@ async function run() {
         await matlab.runCommand(helperScript, platform, architecture, exec.exec, startupOptions);
     });
 
+    // Cleanup post run
     await io.rmRF(workspaceDir + '/.matlab');
+
 }
 
 run().catch((e) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,9 +15,9 @@ async function run() {
     const workspaceDir = process.cwd();
     const pluginResources = "./plugins/+matlab/+ciplugins/+github"
     core.exportVariable('MW_MATLAB_BUILDTOOL_DEFAULT_PLUGINS_FCN_OVERRIDE', 'matlab.ciplugins.github.getDefaultPlugins');
-    const pluginDir = await io.mkdirP(workspceDir + '/.matlab/plugins/+matlab/+ciplugins/+github');
-    const options = { recursive: true, force: false }
-    await io.cp(pluginResources, pluginDir, options);
+    const pluginDir = await io.mkdirP(workspaceDir + '/.matlab/plugins/+matlab/+ciplugins/+github');
+    const opt = { recursive: true, force: false }
+    await io.cp(pluginResources, pluginDir, opt);
 
     const options: buildtool.RunBuildOptions = {
         Tasks: core.getInput("tasks"),

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 
 import * as core from "@actions/core";
 import * as exec from "@actions/exec";
+import * as io from "@actions/io";
 import { matlab } from "run-matlab-command-action";
 import * as buildtool from "./buildtool";
 
@@ -31,6 +32,8 @@ async function run() {
     await core.group("Run command", async () => {
         await matlab.runCommand(helperScript, platform, architecture, exec.exec, startupOptions);
     });
+
+    await io.rmRF(workspaceDir'/.matlab');
 }
 
 run().catch((e) => {


### PR DESCRIPTION
### What this PR contains 
* This PR contains the changes that integrate MATLAB buildtool plugin with GitHub actions 
* This code contains `BuildTaskGroupPlugin` which adds GitHubs workflow command `::group::` before each task run and also adds `::endgroup::` at the end of each task run.
* With this, each build task is grouped using a dropdown arrow in the log as shown below 

<img width="453" alt="image" src="https://github.com/matlab-actions/run-build/assets/47204011/a9bb7153-33fe-424a-b5ca-ac6d09fd1f03">

* Once user click on each build task it will expand it and show the task's run log 

<img width="446" alt="image" src="https://github.com/matlab-actions/run-build/assets/47204011/0f637123-cf29-408d-bcdc-6c5ad3dc9d10">
