### PR TITLE
Parallel safety

### DIFF
--- a/plugins/+ciplugins/+github/ParallelizableBuildReportPlugin.m
+++ b/plugins/+ciplugins/+github/ParallelizableBuildReportPlugin.m
@@ -1,0 +1,70 @@
+classdef ParallelizableBuildReportPlugin < matlab.buildtool.plugins.BuildRunnerPlugin
+
+    %   Copyright 2025 The MathWorks, Inc.
+
+    properties
+        TempFolder
+    end
+
+    methods
+        function plugin = ParallelizableBuildReportPlugin()
+            tempRoot = getenv("RUNNER_TEMP");
+            plugin.TempFolder = fullfile(tempRoot, "taskDetails");
+        end
+    end
+
+    methods (Access=protected)
+        function runBuild(plugin, pluginData)
+            % Create temp folder
+            mkdir(plugin.TempFolder);
+            cleanup = onCleanup(@()rmdir(plugin.TempFolder, "s"));
+ 
+            runBuild@matlab.buildtool.plugins.BuildRunnerPlugin(plugin, pluginData);
+
+            % Construct task details
+            taskDetails = {};
+            fs = what(plugin.TempFolder).mat;
+            for i = 1:numel(fs)
+                f = fs{i};
+                s = load(fullfile(plugin.TempFolder, f));
+                taskDetails = [taskDetails s.taskDetail]; %#ok<AGROW>
+            end
+
+            % Write to file
+            [fID, msg] = fopen(fullfile(getenv("RUNNER_TEMP"), "buildSummary" + getenv("GITHUB_RUN_ID") + ".json"), "w");
+            if fID == -1
+                warning("ciplugins:github:BuildSummaryPlugin:UnableToOpenFile","Unable to open a file required to create the MATLAB build summary table: %s", msg);
+            else
+                closeFile = onCleanup(@()fclose(fID));
+                s = jsonencode(taskDetails);
+                fprintf(fID, "%s", s);
+            end
+        end
+
+        function runTask(plugin, pluginData)
+            runTask@matlab.buildtool.plugins.BuildRunnerPlugin(plugin, pluginData);
+
+            name = fullfile(plugin.TempFolder, pluginData.Name + ".mat");
+            taskDetail = getCommonTaskDetail(pluginData);
+            save(name, "taskDetail");
+        end
+
+        function skipTask(plugin, pluginData)
+            skipTask@matlab.buildtool.plugins.BuildRunnerPlugin(plugin, pluginData);
+
+            name = fullfile(plugin.TempFolder, pluginData.Name + ".mat");
+            taskDetail = getCommonTaskDetail(pluginData);
+            taskDetail.skipReason = pluginData.SkipReason;
+            save(name, "taskDetail");
+        end
+    end
+end
+
+function taskDetail = getCommonTaskDetail(pluginData)
+    taskDetail = struct();
+    taskDetail.name = pluginData.TaskResults.Name;
+    taskDetail.description = pluginData.TaskGraph.Tasks.Description;
+    taskDetail.failed = pluginData.TaskResults.Failed;
+    taskDetail.skipped = pluginData.TaskResults.Skipped;
+    taskDetail.duration = string(pluginData.TaskResults.Duration);
+end

--- a/plugins/+ciplugins/+github/ParallelizableBuildSummaryPlugin.m
+++ b/plugins/+ciplugins/+github/ParallelizableBuildSummaryPlugin.m
@@ -1,4 +1,4 @@
-classdef ParallelizableBuildReportPlugin < matlab.buildtool.plugins.BuildRunnerPlugin
+classdef ParallelizableBuildSummaryPlugin < matlab.buildtool.plugins.BuildRunnerPlugin
 
     %   Copyright 2025 The MathWorks, Inc.
 
@@ -7,7 +7,7 @@ classdef ParallelizableBuildReportPlugin < matlab.buildtool.plugins.BuildRunnerP
     end
 
     methods
-        function plugin = ParallelizableBuildReportPlugin()
+        function plugin = ParallelizableBuildSummaryPlugin()
             tempRoot = getenv("RUNNER_TEMP");
             plugin.TempFolder = fullfile(tempRoot, "taskDetails");
         end

--- a/plugins/+ciplugins/+github/getDefaultPlugins.m
+++ b/plugins/+ciplugins/+github/getDefaultPlugins.m
@@ -1,14 +1,20 @@
 function plugins = getDefaultPlugins(pluginProviderData)
 
-%   Copyright 2024 The MathWorks, Inc.
+%   Copyright 2024-2025 The MathWorks, Inc.
 
 arguments
     pluginProviderData (1,1) struct = struct();
 end
 
+if isMATLABReleaseOlderThan("R2025b")
+    reportPlugin = ciplugins.github.BuildSummaryPlugin();
+else
+    reportPlugin = ciplugins.github.ParallelizableBuildSummaryPlugin();
+end
+
 plugins = [ ...
     matlab.buildtool.internal.getFactoryDefaultPlugins(pluginProviderData) ...
     ciplugins.github.GitHubLogPlugin() ...
-    ciplugins.github.BuildSummaryPlugin() ...
+    reportPlugin ...
 ];
 end


### PR DESCRIPTION
This change adds a new parallel-safe version of the `BuildSummaryPlugin` which will be used for R2025b and later releases. It fixes an issue where `runTaskGraph` is called multiple times in parallel, leading to the summary artifact being incorrectly generated with only the last task run. 

Previous result when run in parallel:
![image](https://github.com/user-attachments/assets/1822ce0f-4450-4f04-87b4-8d5a9e07bb22)


Current result when run in parallel:
![image](https://github.com/user-attachments/assets/f4e5dbe1-1eac-46e2-9db9-7ebc72abe1cb)