### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete string escaping or encoding

### DIFF
--- a/src/buildtool.unit.test.ts
+++ b/src/buildtool.unit.test.ts
@@ -4,7 +4,7 @@ import * as path from "path";
 import * as buildtool from "./buildtool";
 
 describe("command generation", () => {
-const command = "addpath('"+ path.join(__dirname, "plugins").replace("'","''") +"'); buildtool"
+const command = "addpath('"+ path.join(__dirname, "plugins").replace(/'/g,"''") +"'); buildtool"
     it("buildtool invocation with unspecified tasks and build options", () => {
         const options: buildtool.RunBuildOptions = {
             Tasks: "",


### PR DESCRIPTION
Potential fix for [https://github.com/matlab-actions/run-build/security/code-scanning/4](https://github.com/matlab-actions/run-build/security/code-scanning/4)

To fix the problem, every occurrence of a single quote in the returned path string should be replaced with two single quotes, not just the first. Replace the use of `path.join(__dirname, "plugins").replace("'", "''")` with `path.join(__dirname, "plugins").replace(/'/g, "''")`. Only this line (line 7) needs to be changed. No new imports or external libraries are needed since the global replace using regular expressions is well-supported in JavaScript/TypeScript. No other code changes are required in this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
