### PR TITLE
Update version guard from R2025b to R2026a

### DIFF
--- a/plugins/+ciplugins/+github/getDefaultPlugins.m
+++ b/plugins/+ciplugins/+github/getDefaultPlugins.m
@@ -6,7 +6,7 @@ arguments
     pluginProviderData (1,1) struct = struct();
 end
 
-if isMATLABReleaseOlderThan("R2025b")
+if isMATLABReleaseOlderThan("R2026a")
     reportPlugin = ciplugins.github.BuildSummaryPlugin();
 else
     reportPlugin = ciplugins.github.ParallelizableBuildSummaryPlugin();


### PR DESCRIPTION
With the rearrangement of versions, the R2025b guard is no longer correct here. Those changes ended up being pushed to R2026a.

This change updates the version guard to address the issue.